### PR TITLE
Correct status matching

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@ define chsubserver(
     $service    = $key_split[0]
     $proto      = $key_split[1]
 
-    $condition = "grep '^[ \t]*${service}.*${params}' < ${file}"
+    $condition = "grep '^[ \t]*${service}[ \t].*${params}' < ${file}"
 
     if $ensure == "disabled" {
       $_ensure  = "-d"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ define chsubserver(
     Boolean                     $refresh_service  = true,
     String                      $params           = '',
 ) {
-  $file = "/tmp/inetd.conf"
+  $file = "/etc/inetd.conf"
 
   if $key.match(/.+->.+/) {
     $key_split  = split($key, '->')


### PR DESCRIPTION
While trying to fix the $op_match for the case of disabling services, I realized the case of enabling services was weird for when there were multiple lines about that service. This approach here should be more robust.